### PR TITLE
Updated to support new email overloads

### DIFF
--- a/src/NetCore.Utilities.Email.Smtp.Tests/NetCore.Utilities.Email.Smtp.Tests.csproj
+++ b/src/NetCore.Utilities.Email.Smtp.Tests/NetCore.Utilities.Email.Smtp.Tests.csproj
@@ -7,17 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="xunit" Version="2.8.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/NetCore.Utilities.Email.Smtp.Tests/SmtpServiceTests.cs
+++ b/src/NetCore.Utilities.Email.Smtp.Tests/SmtpServiceTests.cs
@@ -286,5 +286,124 @@ namespace ICG.NetCore.Utilities.Email.Smtp.Tests
             _mimeMessageFactoryMock.Verify();
             _mimeKitServiceMock.Verify(k => k.SendEmailAsync(mimeMessage));
         }
+
+        [Fact]
+        public async Task SendWithCustomFromEmailAsync_ShouldSend_WithCustomSender()
+        {
+            var from = "custom@test.com";
+            var fromName = "Custom Sender";
+            var to = "recipient@test.com";
+            var subject = "Subject";
+            var bodyHtml = "<p>Body</p>";
+            var mimeMessage = new MimeMessage();
+            _mimeMessageFactoryMock
+                .Setup(f => f.CreateFromMessage(from, fromName, to, null, subject, bodyHtml, ""))
+                .Returns(mimeMessage).Verifiable();
+            await _service.SendWithCustomFromEmailAsync(from, fromName, to, subject, bodyHtml);
+            _mimeMessageFactoryMock.Verify();
+            _mimeKitServiceMock.Verify(k => k.SendEmailAsync(mimeMessage));
+        }
+
+        [Fact]
+        public async Task SendWithCustomFromEmailAsync_ShouldSend_WithTokens()
+        {
+            var from = "custom@test.com";
+            var fromName = "Custom Sender";
+            var to = "recipient@test.com";
+            var subject = "Subject";
+            var bodyHtml = "Hello, {Name}";
+            var tokens = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("{Name}", "World") };
+            var expectedBody = "Hello, World";
+            var mimeMessage = new MimeMessage();
+            _mimeMessageFactoryMock
+                .Setup(f => f.CreateFromMessage(from, fromName, to, null, subject, expectedBody, ""))
+                .Returns(mimeMessage).Verifiable();
+            await _service.SendWithCustomFromEmailAsync(from, fromName, to, subject, bodyHtml, tokens);
+            _mimeMessageFactoryMock.Verify();
+            _mimeKitServiceMock.Verify(k => k.SendEmailAsync(mimeMessage));
+        }
+
+        [Fact]
+        public async Task SendWithCustomFromEmailAsync_ShouldSend_WithCC()
+        {
+            var from = "custom@test.com";
+            var fromName = "Custom Sender";
+            var to = "recipient@test.com";
+            var cc = new List<string> { "cc@test.com" };
+            var subject = "Subject";
+            var bodyHtml = "<p>Body</p>";
+            var mimeMessage = new MimeMessage();
+            _mimeMessageFactoryMock
+                .Setup(f => f.CreateFromMessage(from, fromName, to, cc, subject, bodyHtml, ""))
+                .Returns(mimeMessage).Verifiable();
+            await _service.SendWithCustomFromEmailAsync(from, fromName, to, cc, subject, bodyHtml);
+            _mimeMessageFactoryMock.Verify();
+            _mimeKitServiceMock.Verify(k => k.SendEmailAsync(mimeMessage));
+        }
+
+        [Fact]
+        public async Task SendWithCustomFromEmailAsync_ShouldSend_WithCCAndTokens()
+        {
+            var from = "custom@test.com";
+            var fromName = "Custom Sender";
+            var to = "recipient@test.com";
+            var cc = new List<string> { "cc@test.com" };
+            var subject = "Subject";
+            var bodyHtml = "Hello, {Name}";
+            var tokens = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("{Name}", "World") };
+            var expectedBody = "Hello, World";
+            var mimeMessage = new MimeMessage();
+            _mimeMessageFactoryMock
+                .Setup(f => f.CreateFromMessage(from, fromName, to, cc, subject, expectedBody, ""))
+                .Returns(mimeMessage).Verifiable();
+            await _service.SendWithCustomFromEmailAsync(from, fromName, to, cc, subject, bodyHtml, tokens);
+            _mimeMessageFactoryMock.Verify();
+            _mimeKitServiceMock.Verify(k => k.SendEmailAsync(mimeMessage));
+        }
+
+        [Fact]
+        public async Task SendWithCustomFromEmailAsync_ShouldSend_WithTemplateAndSenderKey()
+        {
+            var from = "custom@test.com";
+            var fromName = "Custom Sender";
+            var to = "recipient@test.com";
+            var cc = new List<string> { "cc@test.com" };
+            var subject = "Subject";
+            var bodyHtml = "<p>Body</p>";
+            var tokens = new List<KeyValuePair<string, string>>();
+            var templateName = "CustomTemplate";
+            var senderKeyName = "SenderKey";
+            var mimeMessage = new MimeMessage();
+            _mimeMessageFactoryMock
+                .Setup(f => f.CreateFromMessage(from, fromName, to, cc, subject, bodyHtml, templateName))
+                .Returns(mimeMessage).Verifiable();
+            await _service.SendWithCustomFromEmailAsync(from, fromName, to, cc, subject, bodyHtml, tokens, templateName, senderKeyName);
+            _mimeMessageFactoryMock.Verify();
+            _mimeKitServiceMock.Verify(k => k.SendEmailAsync(mimeMessage));
+        }
+
+        [Fact]
+        public async Task SendWithCustomFromEmailAndAttachmentAsync_ShouldSend_WithAllParameters()
+        {
+            var from = "custom@test.com";
+            var fromName = "Custom Sender";
+            var to = "recipient@test.com";
+            var cc = new List<string> { "cc@test.com" };
+            var subject = "Subject";
+            var fileContent = Encoding.ASCII.GetBytes("Attachment");
+            var fileName = "file.txt";
+            var bodyHtml = "Hello, {Name}";
+            var tokens = new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("{Name}", "World") };
+            var expectedBody = "Hello, World";
+            var templateName = "CustomTemplate";
+            var senderKeyName = "SenderKey";
+            var mimeMessage = new MimeMessage();
+            _mimeMessageFactoryMock
+                .Setup(f => f.CreateFromMessageWithAttachment(from, fromName, to, cc, subject, fileContent, fileName, expectedBody, templateName))
+                .Returns(mimeMessage).Verifiable();
+            await _service.SendWithCustomFromEmailAndAttachmentAsync(from, fromName, to, cc, subject, fileContent, fileName, bodyHtml, tokens, templateName, senderKeyName);
+            _mimeMessageFactoryMock.Verify();
+            _mimeKitServiceMock.Verify(k => k.SendEmailAsync(mimeMessage));
+        }
     }
 }

--- a/src/NetCore.Utilities.Email.Smtp/NetCore.Utilities.Email.Smtp.csproj
+++ b/src/NetCore.Utilities.Email.Smtp/NetCore.Utilities.Email.Smtp.csproj
@@ -25,7 +25,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$GITHUB_ACTIONS)' == 'true'">
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
 	<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>

--- a/src/NetCore.Utilities.Email.Smtp/NetCore.Utilities.Email.Smtp.csproj
+++ b/src/NetCore.Utilities.Email.Smtp/NetCore.Utilities.Email.Smtp.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="icg.netcore.utilities.email" Version="7.0.0" />
-    <PackageReference Include="MailKit" Version="4.6.0" />
+    <PackageReference Include="icg.netcore.utilities.email" Version="8.1.0" />
+    <PackageReference Include="MailKit" Version="4.13.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />

--- a/src/NetCore.Utilities.Email.Smtp/SmtpService.cs
+++ b/src/NetCore.Utilities.Email.Smtp/SmtpService.cs
@@ -177,5 +177,62 @@ namespace ICG.NetCore.Utilities.Email.Smtp
             await _mimeKitService.SendEmailAsync(toSend);
             return true;
         }
+
+        /// <inheritdoc />
+        public async Task<bool> SendWithCustomFromEmailAsync(string fromAddress, string fromName, string toAddress, string subject, string bodyHtml)
+        {
+            return await SendWithCustomFromEmailAsync(fromAddress, fromName, toAddress, null, subject, bodyHtml, null, "");
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> SendWithCustomFromEmailAsync(string fromAddress, string fromName, string toAddress, string subject, string bodyHtml, List<KeyValuePair<string, string>> tokens)
+        {
+            return await SendWithCustomFromEmailAsync(fromAddress, fromName, toAddress, null, subject, bodyHtml, tokens, "");
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> SendWithCustomFromEmailAsync(string fromAddress, string fromName, string toAddress, IEnumerable<string> ccAddressList, string subject, string bodyHtml)
+        {
+            return await SendWithCustomFromEmailAsync(fromAddress, fromName, toAddress, ccAddressList, subject, bodyHtml, null, "");
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> SendWithCustomFromEmailAsync(string fromAddress, string fromName, string toAddress, IEnumerable<string> ccAddressList, string subject, string bodyHtml, List<KeyValuePair<string, string>> tokens)
+        {
+            return await SendWithCustomFromEmailAsync(fromAddress, fromName, toAddress, ccAddressList, subject, bodyHtml, tokens, "");
+        }
+
+        /// <inheritdoc />
+        public async Task<bool> SendWithCustomFromEmailAsync(string fromAddress, string fromName, string toAddress, IEnumerable<string> ccAddressList, string subject, string bodyHtml, List<KeyValuePair<string, string>> tokens, string templateName, string senderKeyName = "")
+        {
+            if (tokens != null)
+            {
+                foreach (var item in tokens)
+                {
+                    bodyHtml = bodyHtml.Replace(item.Key, item.Value);
+                }
+            }
+            var toSend = _mimeMessageFactory.CreateFromMessage(fromAddress, fromName, toAddress, ccAddressList, subject, bodyHtml, templateName);
+            await _mimeKitService.SendEmailAsync(toSend);
+            return true;
+        }
+
+
+        /// <inheritdoc />
+        public async Task<bool> SendWithCustomFromEmailAndAttachmentAsync(string fromAddress, string fromName, string toAddress, IEnumerable<string> ccAddressList, string subject,
+        byte[] fileContent, string fileName, string bodyHtml, List<KeyValuePair<string, string>> tokens,
+            string templateName = "", string senderKeyName = "")
+        {
+            if (tokens != null)
+            {
+                foreach (var item in tokens)
+                {
+                    bodyHtml = bodyHtml.Replace(item.Key, item.Value);
+                }
+            }
+            var toSend = _mimeMessageFactory.CreateFromMessageWithAttachment(fromAddress, fromName, toAddress, ccAddressList, subject, fileContent, fileName, bodyHtml, templateName);
+            await _mimeKitService.SendEmailAsync(toSend);
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Updated to support new email overloads

- Fixes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Send emails with a custom From name/address, including CC recipients, tokenized content, optional template/sender key, and attachments.

- Tests
  - Added tests covering custom From, CC, token replacement, template/sender key usage, and attachment scenarios.

- Chores
  - Upgraded SMTP and related libraries; updated test framework and coverage tool versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->